### PR TITLE
gitignore public uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 
 # Ignore Byebug command history file.
 .byebug_history
+
+public/uploads/*


### PR DESCRIPTION
#what
画像がGithubにコミットされないにする

#why
投稿された画像自体はソースコードには関係のないものだから